### PR TITLE
Replace shortDescription with the one currently shown on the app market

### DIFF
--- a/.sandstorm/shortDescription.txt
+++ b/.sandstorm/shortDescription.txt
@@ -1,1 +1,1 @@
-A simple wrapper around GitWeb and git-http-backend, providing an extremely lightweight way to host a web-browsable Git repository.
+Git hosting


### PR DESCRIPTION
I intend to use shortDescriptions in the app list, and the app market overrides
are not available there.
