### PR TITLE
Simplify offer template

### DIFF
--- a/.sandstorm/usr/share/gitweb/indextext.html
+++ b/.sandstorm/usr/share/gitweb/indextext.html
@@ -1,5 +1,5 @@
 <div>
-<p> You can clone this repo by running these commands:</p>
+<p> You can clone this repo by running this command:</p>
 </div>
 <div>
   <iframe id="offer-iframe"></iframe>
@@ -7,7 +7,7 @@
 <style>
   #offer-iframe {
    width: 100%;
-   height: 55px;
+   height: 35px;
   }
 </style>
 <script type="text/javascript" src="sandstorm.js">

--- a/.sandstorm/usr/share/gitweb/sandstorm.js
+++ b/.sandstorm/usr/share/gitweb/sandstorm.js
@@ -17,21 +17,8 @@ var messageListener = function(event) {
   }
 };
 
-var username = "any_username";
-if (window.crypto) {
-  var array = new Uint32Array(8);
-  window.crypto.getRandomValues(array);
-  username = "";
-  for (var ii = 0; ii < array.length; ++ii) {
-    username = username + String.fromCharCode(97 + (array[ii] % 26));
-  }
-}
-
 window.addEventListener("message", messageListener);
-var template =
-    " echo url=" + window.location.protocol + "//" + username + ":$API_TOKEN@$API_HOST/ |" +
-    " git -c credential.helper=store credential approve\n" +
-    " git clone -c credential.helper=store " + window.location.protocol + "//" + username + "@$API_HOST/ repo_" + username + "_RENAME_ME\n";
+var template = "git clone " + window.location.protocol + "//git:$API_TOKEN@$API_HOST\n";
 window.parent.postMessage({renderTemplate: {rpcId: "0", template: template}}, "*");
 
 });


### PR DESCRIPTION
Instead of storing credentials using `git-credential-store`, just embed them in the remote URL.

* When making many short-lived clones, this avoids polluting `~/.git-credentials`.
* Shortens offer to a single command, which is easier to work with.